### PR TITLE
Update pyVCfind.py

### DIFF
--- a/pyVCfind.py
+++ b/pyVCfind.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from shutil import get_terminal_size
-from colorama import Fore
+from colorama import Fore, deinit
 from colorama import init
 import threading
 import argparse
@@ -69,6 +69,7 @@ def error(msg: str):
         print(f"{RED}[!]{RESET} {msg}")
     else:
         print(f"[!] {msg}")
+    deinit()
     sys.exit(1)
 
 
@@ -166,6 +167,7 @@ def print_findings():
             print(symbol[int(finding.verify_entropy)] +  " entropy:   " + str(finding.entropy))
             print(symbol[int(finding.verify_signature)] +  " signature: " + str(finding.signature))
             print()
+            
 
 def main():
     ap = argparse.ArgumentParser()
@@ -208,6 +210,7 @@ def main():
     t2 = time.time()
     print_findings()
     info(f"Took {round(t2-t1, 2)}s to execute")
+    deinit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On Windows, calling init() will filter ANSI escape sequences out of any text sent to stdout or stderr, and replace them with equivalent Win32 calls.

On other platforms, calling init() has no effect (unless you request other optional functionalit). By design, this permits applications to call init() unconditionally on all platforms, after which ANSI output should just work.

To stop filter ANSI escape sequences before program exits, we're calling deinit()